### PR TITLE
Add TitleText component with optional subtitle

### DIFF
--- a/src/TitleText.tsx
+++ b/src/TitleText.tsx
@@ -8,20 +8,20 @@ export interface TitleTextProps {
 
 const TITLE_CLASS = "text-2xl font-bold text-white text-center select-none";
 
+
 export class TitleText extends Component<TitleTextProps> {
     render() {
+        const TITLE = <h1 className={TITLE_CLASS}>
+            {this.props.children}
+        </h1>;
         if (!this.props.subtitle) {
             return (
-                <h1 className={TITLE_CLASS}>
-                    {this.props.children}
-                </h1>
+                TITLE
             );
         }
         return (
             <div className="flex flex-col flex-1">
-                <h1 className={TITLE_CLASS}>
-                    {this.props.children}
-                </h1>
+                {TITLE}
                 <Typography variant="subtitle2" align="center" className="text-white select-none">
                     {this.props.subtitle}
                 </Typography>

--- a/src/TitleText.tsx
+++ b/src/TitleText.tsx
@@ -1,24 +1,30 @@
 import {Component, type ReactNode} from "react";
-interface TitleTextProps {
+import Typography from '@mui/material/Typography';
+
+export interface TitleTextProps {
     children: ReactNode;
     subtitle?: string;
 }
+
+const TITLE_CLASS = "text-2xl font-bold text-white text-center select-none";
 
 export class TitleText extends Component<TitleTextProps> {
     render() {
         if (!this.props.subtitle) {
             return (
-                <h1 className="text-2xl font-bold text-white text-center select-none">
+                <h1 className={TITLE_CLASS}>
                     {this.props.children}
                 </h1>
             );
         }
         return (
             <div className="flex flex-col flex-1">
-                <h1 className="text-2xl font-bold text-white text-center select-none">
+                <h1 className={TITLE_CLASS}>
                     {this.props.children}
                 </h1>
-                <h2 className="text-sm text-white text-center select-none">{this.props.subtitle}</h2>
+                <Typography variant="subtitle2" align="center" className="text-white select-none">
+                    {this.props.subtitle}
+                </Typography>
             </div>
         );
     }

--- a/src/TitleText.tsx
+++ b/src/TitleText.tsx
@@ -1,0 +1,25 @@
+import {Component, type ReactNode} from "react";
+interface TitleTextProps {
+    children: ReactNode;
+    subtitle?: string;
+}
+
+export class TitleText extends Component<TitleTextProps> {
+    render() {
+        if (!this.props.subtitle) {
+            return (
+                <h1 className="text-2xl font-bold text-white text-center select-none">
+                    {this.props.children}
+                </h1>
+            );
+        }
+        return (
+            <div className="flex flex-col flex-1">
+                <h1 className="text-2xl font-bold text-white text-center select-none">
+                    {this.props.children}
+                </h1>
+                <h2 className="text-sm text-white text-center select-none">{this.props.subtitle}</h2>
+            </div>
+        );
+    }
+}

--- a/src/TitleText.tsx
+++ b/src/TitleText.tsx
@@ -11,17 +11,17 @@ const TITLE_CLASS = "text-2xl font-bold text-white text-center select-none";
 
 export class TitleText extends Component<TitleTextProps> {
     render() {
-        const TITLE = <h1 className={TITLE_CLASS}>
+        const title = <h1 className={TITLE_CLASS}>
             {this.props.children}
         </h1>;
         if (!this.props.subtitle) {
             return (
-                TITLE
+                title
             );
         }
         return (
             <div className="flex flex-col flex-1">
-                {TITLE}
+                {title}
                 <Typography variant="subtitle2" align="center" className="text-white select-none">
                     {this.props.subtitle}
                 </Typography>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable title component that displays a centered main title and, when provided, an optional centered subtitle beneath it for consistent page headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

