### PR TITLE
Extract menu functionality from AppBarContents to AppBarMenu

### DIFF
--- a/src/AppBar.tsx
+++ b/src/AppBar.tsx
@@ -11,6 +11,6 @@ export class AppBar extends Component<AppBarProps> {
                     {this.props.children}
                 </header>
             </>
-        )
+        );
     }
 }

--- a/src/AppBarContents.tsx
+++ b/src/AppBarContents.tsx
@@ -1,45 +1,15 @@
-import React, { Component } from "react";
-import { IconButton, Menu, MenuItem, ListItemIcon, ListItemText } from "@mui/material";
-import { Menu as MenuIcon, Home as HomeIcon } from "@mui/icons-material";
+import { Component } from "react";
 import { RefreshButton } from "./RefreshButton.tsx";
+import {AppBarMenu} from "./AppBarMenu.tsx";
 
-interface State {
-    anchorEl: HTMLElement | null;
-}
 
-export class AppBarContents extends Component<object, State> {
-    state: State = {
-        anchorEl: null,
-    };
 
-    // anchorEl being truthy replaces the need for a separate 'open' boolean
-    handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        this.setState({ anchorEl: event.currentTarget });
-    };
-
-    handleClose = () => {
-        this.setState({ anchorEl: null });
-    };
-
+export class AppBarContents extends Component<object> {
     render() {
-        const { anchorEl } = this.state;
-        const open = Boolean(anchorEl);
-
         return (
             /* Main Container: Flex row that stretches across the top */
             <div className="flex flex-row items-center justify-between w-full h-16 px-4 ">
-
-                {/* Left Section: Menu Toggle */}
-                <div className="flex-none">
-                    <IconButton
-                        onClick={this.handleClick}
-                        size="large"
-                        className="text-white"
-                    >
-                        <MenuIcon />
-                    </IconButton>
-                </div>
-
+                <AppBarMenu />
                 {/* Center Section: Branding */}
                 <div className="flex flex-col flex-1">
                     <h1 className="text-2xl font-bold text-white text-center select-none">
@@ -53,19 +23,7 @@ export class AppBarContents extends Component<object, State> {
                     <RefreshButton />
                 </div>
 
-                {/* Menu Component (Renders outside the flow) */}
-                <Menu
-                    anchorEl={anchorEl}
-                    open={open}
-                    onClose={this.handleClose}
-                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                    transformOrigin={{ vertical: "top", horizontal: "left" }}
-                >
-                    <MenuItem onClick={this.handleClose}>
-                        <ListItemIcon><HomeIcon /></ListItemIcon>
-                        <ListItemText>Homepage</ListItemText>
-                    </MenuItem>
-                </Menu>
+
             </div>
         );
     }

--- a/src/AppBarContents.tsx
+++ b/src/AppBarContents.tsx
@@ -1,6 +1,6 @@
 import { Component } from "react";
 import { RefreshButton } from "./RefreshButton.tsx";
-import {AppBarMenu} from "./AppBarMenu.tsx";
+import { AppBarMenu } from "./AppBarMenu.tsx";
 
 
 
@@ -15,7 +15,7 @@ export class AppBarContents extends Component<object> {
                     <h1 className="text-2xl font-bold text-white text-center select-none">
                         UP Inc.
                     </h1>
-                    <h2 className="text-1xl text-white text-center select-none">Where Dreams come true</h2>
+                    <h2 className="text-xl text-white text-center select-none">Where Dreams come true</h2>
                 </div>
 
                 {/* Right Section: Actions */}

--- a/src/AppBarMenu.tsx
+++ b/src/AppBarMenu.tsx
@@ -1,0 +1,63 @@
+import React, {Component} from "react";
+import {Menu} from "@mui/material";
+import MenuItem from "@mui/material/MenuItem";
+import IconButton from "@mui/material/IconButton";
+import MenuIcon from "@mui/icons-material/Menu"
+import HomeIcon from "@mui/icons-material/Home"
+import {ListItemIcon} from "@mui/material";
+import ListItemText from "@mui/material/ListItemText";
+
+interface State {
+    anchorEl: HTMLElement | null;
+}
+
+
+export class AppBarMenu extends Component {
+    state: State = {
+        anchorEl: null,
+    };
+    menuId = `menu-${Math.random().toString(36).slice(2, 11)}`;
+    // anchorEl being truthy replaces the need for a separate 'open' boolean
+    handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        this.setState({ anchorEl: event.currentTarget });
+    };
+
+    handleClose = () => {
+        this.setState({ anchorEl: null });
+    };
+    render() {
+        const { anchorEl } = this.state;
+        const open = Boolean(anchorEl);
+        return (
+            <>
+                {/* Left Section: Menu Toggle */}
+                <div className="flex-none">
+                    <IconButton
+                        onClick={this.handleClick}
+                        size="large"
+                        className="text-white"
+                        aria-controls={open ? this.menuId : undefined}
+                        aria-haspopup="true"
+                        aria-expanded={open ? "true" : undefined}
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                </div>
+                {/* Menu Component (Renders outside the flow) */}
+                <Menu
+                    anchorEl={anchorEl}
+                    open={open}
+                    onClose={this.handleClose}
+                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+                    transformOrigin={{ vertical: "top", horizontal: "left" }}
+                    id={this.menuId}
+                >
+                    <MenuItem onClick={this.handleClose}>
+                        <ListItemIcon><HomeIcon /></ListItemIcon>
+                        <ListItemText>Homepage</ListItemText>
+                    </MenuItem>
+                </Menu>
+            </>
+        )
+    }
+}

--- a/src/AppBarMenu.tsx
+++ b/src/AppBarMenu.tsx
@@ -35,6 +35,7 @@ export class AppBarMenu extends Component<object, State> {
                         aria-controls={open ? this.menuId : undefined}
                         aria-haspopup="true"
                         aria-expanded={open ? "true" : undefined}
+                        aria-label="Open menu"
                     >
                         <MenuIcon />
                     </IconButton>

--- a/src/AppBarMenu.tsx
+++ b/src/AppBarMenu.tsx
@@ -1,18 +1,14 @@
 import React, {Component} from "react";
-import {Menu} from "@mui/material";
-import MenuItem from "@mui/material/MenuItem";
-import IconButton from "@mui/material/IconButton";
+import {Menu, MenuItem, IconButton, ListItemIcon, ListItemText} from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu"
 import HomeIcon from "@mui/icons-material/Home"
-import {ListItemIcon} from "@mui/material";
-import ListItemText from "@mui/material/ListItemText";
 
 interface State {
     anchorEl: HTMLElement | null;
 }
 
 
-export class AppBarMenu extends Component {
+export class AppBarMenu extends Component<object, State> {
     state: State = {
         anchorEl: null,
     };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Menu functionality moved into a dedicated, self-contained component for improved modularity; left-side menu button and "Homepage" menu item remain available in the app bar with unchanged behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->